### PR TITLE
[Claude] Support relative paths (./ and ../) in nested include directives

### DIFF
--- a/hi_scripting/scripting/ScriptProcessor.cpp
+++ b/hi_scripting/scripting/ScriptProcessor.cpp
@@ -1883,9 +1883,9 @@ void JavascriptProcessor::restoreInterfaceData(ValueTree propertyData)
 	}
 }
 
-String JavascriptProcessor::Helpers::resolveIncludeStatements(String& x, Array<File>& includedFiles, const JavascriptProcessor* p)
+String JavascriptProcessor::Helpers::resolveIncludeStatements(String& x, Array<File>& includedFiles, const JavascriptProcessor* p, const File& parentFile)
 {
-	String regex("include\\(\"(?:\\{GLOBAL_SCRIPT_FOLDER\\})?([/\\w\\s]+\\.\\w+)\"\\);");
+	String regex("include\\(\"([^\"]+)\"\\);");
 	StringArray results = RegexFunctions::search(regex, x, 0);
 	StringArray fileNames = RegexFunctions::search(regex, x, 1);
 	StringArray includedContents;
@@ -1894,20 +1894,31 @@ String JavascriptProcessor::Helpers::resolveIncludeStatements(String& x, Array<F
 
 	static const String globalWildcard("{GLOBAL_SCRIPT_FOLDER}");
 
+	auto scriptsDir = GET_PROJECT_HANDLER(dynamic_cast<const Processor*>(p)).getSubDirectory(ProjectHandler::SubDirectories::Scripts);
+
 	for (int i = 0; i < fileNames.size(); i++)
-	{				
+	{
 		File f;
-		
-		auto isGlobalScript = results[i].contains(globalWildcard);
+
+		auto isGlobalScript = fileNames[i].contains(globalWildcard);
+		auto isRelativePath = fileNames[i].startsWith("./") || fileNames[i].startsWith("../");
 
 		if (isGlobalScript)
 		{
-			f = globalScriptFolder.getChildFile(fileNames[i]).getFullPathName();
+			auto relativePart = fileNames[i].fromFirstOccurrenceOf(globalWildcard, false, false);
+			f = globalScriptFolder.getChildFile(relativePart).getFullPathName();
+		}
+		else if (isRelativePath)
+		{
+			if (parentFile.existsAsFile())
+				f = parentFile.getParentDirectory().getChildFile(fileNames[i]).getFullPathName();
+			else
+				f = scriptsDir.getChildFile(fileNames[i]).getFullPathName();
 		}
 		else
 		{
 			f = File::isAbsolutePath(fileNames[i]) ? File(fileNames[i]) :
-				GET_PROJECT_HANDLER(dynamic_cast<const Processor*>(p)).getSubDirectory(ProjectHandler::SubDirectories::Scripts).getChildFile(fileNames[i]);	
+				scriptsDir.getChildFile(fileNames[i]);
 		}
 
 		if (includedFiles.contains(f)) // skip multiple inclusions...
@@ -1919,16 +1930,18 @@ String JavascriptProcessor::Helpers::resolveIncludeStatements(String& x, Array<F
 		includedFiles.add(f);
 		String content = f.loadFileAsString();
 
-		content = resolveIncludeStatements(content, includedFiles, p);
+		content = resolveIncludeStatements(content, includedFiles, p, f);
 
 		String thisContent;
 
 		String fileRef;
 
 		if (isGlobalScript)
-			fileRef << globalWildcard;
-
-		fileRef << fileNames[i];
+			fileRef << fileNames[i];
+		else if (isRelativePath)
+			fileRef << f.getRelativePathFrom(scriptsDir);
+		else
+			fileRef << fileNames[i];
 
 		thisContent << "\n//{BEGIN}" + fileRef << "\n";
 		thisContent << content;

--- a/hi_scripting/scripting/ScriptProcessor.h
+++ b/hi_scripting/scripting/ScriptProcessor.h
@@ -723,7 +723,7 @@ private:
 
 		
 
-		static String resolveIncludeStatements(String& x, Array<File>& includedFiles, const JavascriptProcessor* p);
+		static String resolveIncludeStatements(String& x, Array<File>& includedFiles, const JavascriptProcessor* p, const File& parentFile = File());
 		static Array<ExternalScript> desolveIncludeStatements(String& x, const File& scriptRoot, MainController* mc);
 
 		static String stripUnusedNamespaces(const String &code, int& counter);

--- a/hi_scripting/scripting/engine/JavascriptEngineParser.cpp
+++ b/hi_scripting/scripting/engine/JavascriptEngineParser.cpp
@@ -848,8 +848,23 @@ private:
 
 #if USE_BACKEND
 
-		if (File::isAbsolutePath(cleanedFileName)) 
+		if (File::isAbsolutePath(cleanedFileName))
 			refFileName = cleanedFileName;
+		else if (cleanedFileName.startsWith("./") || cleanedFileName.startsWith("../"))
+		{
+			// Resolve relative to the directory of the currently parsed file
+			if (location.externalFile.isNotEmpty())
+			{
+				File currentFile(location.externalFile);
+				refFileName = currentFile.getParentDirectory().getChildFile(cleanedFileName).getFullPathName();
+			}
+			else
+			{
+				// No parent file context, fall back to project Scripts directory
+				const String fileName = "{PROJECT_FOLDER}" + cleanedFileName;
+				refFileName = GET_PROJECT_HANDLER(dynamic_cast<Processor*>(hiseSpecialData->processor)).getFilePath(fileName, ProjectHandler::SubDirectories::Scripts);
+			}
+		}
 		else if (cleanedFileName.contains("{GLOBAL_SCRIPT_FOLDER}"))
 		{
 			File globalScriptFolder = PresetHandler::getGlobalScriptFolder(dynamic_cast<Processor*>(hiseSpecialData->processor));

--- a/hi_scripting/scripting/engine/JavascriptEngineParser.cpp
+++ b/hi_scripting/scripting/engine/JavascriptEngineParser.cpp
@@ -2626,11 +2626,17 @@ void HiseJavascriptEngine::RootObject::ExpressionTreeBuilder::preprocessCode(con
 			it.match(TokenTypes::include_);
 			it.match(TokenTypes::openParen);
 			String fileName = it.currentValue.toString();
+
+			auto previousExternalFilePath = currentExternalFilePath;
+			currentExternalFilePath = externalFileName;
+
 			String externalCode = getFileContent(it.currentValue.toString(), fileName);
-			
-            
-            
+
+
+
 			preprocessCode(externalCode, fileName);
+
+			currentExternalFilePath = previousExternalFilePath;
 
 			continue;
 		}

--- a/hi_scripting/scripting/engine/JavascriptEngineParser.cpp
+++ b/hi_scripting/scripting/engine/JavascriptEngineParser.cpp
@@ -271,7 +271,8 @@ struct HiseJavascriptEngine::RootObject::ExpressionTreeBuilder : private TokenIt
 	ExpressionTreeBuilder(const String code, const String externalFile, HiseJavascriptPreprocessor::Ptr preprocessor_) :
 		TokenIterator(code, externalFile),
 		preprocessor(preprocessor_),
-	    currentErrorLocation(nullptr)
+	    currentErrorLocation(nullptr),
+	    currentExternalFilePath(externalFile)
 	{
 #if ENABLE_SCRIPTING_BREAKPOINTS
 		if (externalFile.isNotEmpty())
@@ -282,6 +283,9 @@ struct HiseJavascriptEngine::RootObject::ExpressionTreeBuilder : private TokenIt
 	}
 
     HiseJavascriptPreprocessor::Ptr preprocessor;
+
+	/** The full path of the file currently being parsed (used for resolving relative includes). */
+	String currentExternalFilePath;
 
 	void setupApiData(HiseSpecialData &data, const String& codeToPreprocess)
 	{
@@ -853,9 +857,9 @@ private:
 		else if (cleanedFileName.startsWith("./") || cleanedFileName.startsWith("../"))
 		{
 			// Resolve relative to the directory of the currently parsed file
-			if (location.externalFile.isNotEmpty())
+			if (currentExternalFilePath.isNotEmpty())
 			{
-				File currentFile(location.externalFile);
+				File currentFile(currentExternalFilePath);
 				refFileName = currentFile.getParentDirectory().getChildFile(cleanedFileName).getFullPathName();
 			}
 			else


### PR DESCRIPTION
Allow include() to use relative paths that resolve relative to the
directory of the file containing the include statement. This enables
nested includes to reference sibling files without requiring absolute
paths or {GLOBAL_SCRIPT_FOLDER} prefixes.

- Add relative path resolution in getFileContent() for ./ and ../ paths
- Add currentExternalFilePath member to ExpressionTreeBuilder to track
  the file being parsed for relative path context
- Update preprocessCode() to propagate parent file path when processing
  nested includes
- Update resolveIncludeStatements() with broader regex and parentFile
  parameter for recursive relative path resolution during script export
